### PR TITLE
Fix for PHP notice in PHP 7.1

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === WordPress Beta Tester  ===
 Tags: beta, advanced, testing
 Contributors: westi, mlteal, afragen
-Tested up to: 4.7
+Tested up to: 4.8
 Requires at least: 3.0.5
-Stable Tag: 1.1.0
+Stable Tag: 1.1.1
 License: GPLv2
 License URI: http://www.opensource.org/licenses/GPL-2.0
 
@@ -21,6 +21,9 @@ For the more adventurous there is the option to switch to the bleeding edge of d
 Don't forget to backup before you start!
 
 == Changelog ==
+
+= 1.1.1 =
+* fix PHP notice for PHP 7.1
 
 = 1.1.0 =
 * Fixed to work properly under Multisite.

--- a/wp-beta-tester.php
+++ b/wp-beta-tester.php
@@ -155,6 +155,8 @@ class wp_beta_tester {
 			return $wp_version;
 		}
 
+		$preferred->current = substr( $preferred->current, 0, strpos( $preferred->current, '-' ) );
+
 		switch ( $stream ) {
 			case 'point':
 				$versions    = explode( '.', $preferred->current );

--- a/wp-beta-tester.php
+++ b/wp-beta-tester.php
@@ -4,7 +4,7 @@
 	Plugin URI: https://wordpress.org/plugins/wordpress-beta-tester/
 	Description: Allows you to easily upgrade to Beta releases.
 	Author: Peter Westwood
-	Version: 1.1.0
+	Version: 1.1.1
 	Network: true
 	Author URI: http://blog.ftwr.co.uk/
 	Text Domain: wordpress-beta-tester
@@ -164,7 +164,7 @@ class wp_beta_tester {
 				$wp_version  = $versions[0] . '.' . $versions[1] . '.' . $versions[2] . '-wp-beta-tester';
 				break;
 			case 'unstable':
-				$versions = explode( '.', $preferred->current );
+				$versions    = explode( '.', $preferred->current );
 				$versions[1] += 1;
 				if ( 10 == $versions[1] ) {
 					$versions[0] += 1;

--- a/wp-beta-tester.php
+++ b/wp-beta-tester.php
@@ -155,16 +155,14 @@ class wp_beta_tester {
 			return $wp_version;
 		}
 
-		$preferred->current = substr( $preferred->current, 0, strpos( $preferred->current, '-' ) );
+		$versions = array_map( 'intval', explode( '.', $preferred->current ) );
 
 		switch ( $stream ) {
 			case 'point':
-				$versions    = explode( '.', $preferred->current );
 				$versions[2] = isset( $versions[2] ) ? $versions[2] + 1 : 1;
 				$wp_version  = $versions[0] . '.' . $versions[1] . '.' . $versions[2] . '-wp-beta-tester';
 				break;
 			case 'unstable':
-				$versions    = explode( '.', $preferred->current );
 				$versions[1] += 1;
 				if ( 10 == $versions[1] ) {
 					$versions[0] += 1;


### PR DESCRIPTION
The following error notice displays, http://php.net/manual/en/migration71.other-changes.php

This PR fixes.

line 166 attempts to do the following where `$versions[1] = '8-alpha-40422'`, `$versions[1] += 1`, the result seems to be 9 but gives the notice for coercion.